### PR TITLE
Upgrade to use JCasC test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.39</version>
+        <version>3.56</version>
         <relativePath />
     </parent>
 
@@ -95,7 +95,7 @@
         <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
 
         <!-- Test scope -->
-        <configuration-as-code.version>1.34</configuration-as-code.version>
+        <configuration-as-code.version>1.35</configuration-as-code.version>
         <equalsverifier.version>3.1.10</equalsverifier.version>
         <mockito-core.version>3.2.0</mockito-core.version>
         <concurrency>2</concurrency>
@@ -282,10 +282,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
             <version>${configuration-as-code.version}</version>
-            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again.

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please