### PR TITLE
Support new version scheme

### DIFF
--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/util/ToolVersion.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/util/ToolVersion.java
@@ -30,6 +30,17 @@ public final class ToolVersion implements Comparable<ToolVersion>, Serializable 
      *
      * @param major the major version
      * @param minor the minor version
+     * @param qualifier the qualifier version
+     */
+    public ToolVersion(final int major, final int minor, final String qualifier) {
+        this(major, minor, 0, qualifier);
+    }
+
+    /**
+     * Instantiates a new {@link ToolVersion}.
+     *
+     * @param major the major version
+     * @param minor the minor version
      * @param micro the micro version
      */
     public ToolVersion(final int major, final int minor, final int micro) {
@@ -65,17 +76,23 @@ public final class ToolVersion implements Comparable<ToolVersion>, Serializable 
      * @throws IllegalArgumentException if the format of the version string is invalid
      */
     public static ToolVersion parse(final String version) throws IllegalArgumentException {
-        final Pattern pattern = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:[.#](.*))?$");
+        final Pattern pattern = Pattern.compile("^(\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:[.#](.*))?$");
         final Matcher matcher = pattern.matcher(version);
         if (!matcher.find() || matcher.groupCount() != 4) {
             throw new IllegalArgumentException(
-                    "Version must be in form <major>.<minor>.<micro>.<qualifier>");
+                    "Version must be in form <major>.<minor>[.<micro>][.<qualifier>]");
         }
 
         final int major = Integer.parseInt(matcher.group(1));
         final int minor = Integer.parseInt(matcher.group(2));
-        final int micro = Integer.parseInt(matcher.group(3));
-        final String qualifier = matcher.group(4);
+        int micro = 0;
+        if (matcher.group(3) != null) {
+            micro = Integer.parseInt(matcher.group(3));
+        }
+        String qualifier = "";
+        if (matcher.group(4) != null) {
+            qualifier = matcher.group(4);
+        }
 
         return new ToolVersion(major, minor, micro, qualifier);
     }

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/util/ToolVersionTest.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/util/ToolVersionTest.java
@@ -36,6 +36,27 @@ public class ToolVersionTest {
     }
 
     @Test
+    public void testParseValidToolVersionWithoutMicro() {
+        final ToolVersion expectedToolVersion = new ToolVersion(2020, 3, "100255+67b65c");
+        final ToolVersion parsedToolVersion = ToolVersion.parse("2020.3.100255+67b65c");
+        assertEquals("Check parsed version", expectedToolVersion, parsedToolVersion);
+    }
+
+    @Test
+    public void testParseValidToolVersionWithoutQualifier() {
+        final ToolVersion expectedToolVersion = new ToolVersion(8, 1, 0);
+        final ToolVersion parsedToolVersion = ToolVersion.parse("8.1.0");
+        assertEquals("Check parsed version", expectedToolVersion, parsedToolVersion);
+    }
+
+    @Test
+    public void testParseValidToolVersionWithoutBoth() {
+        final ToolVersion expectedToolVersion = new ToolVersion(8, 1, 0, "");
+        final ToolVersion parsedToolVersion = ToolVersion.parse("8.1");
+        assertEquals("Check parsed version", expectedToolVersion, parsedToolVersion);
+    }
+
+    @Test
     public void testParseHighToolVersion() {
         final ToolVersion expectedToolVersion = new ToolVersion(1000, 2000, 3000, "4000");
         final ToolVersion parsedToolVersion = ToolVersion.parse("1000.2000.3000.4000");


### PR DESCRIPTION
ToolVersion.parse: micro is optional (omitted if zero since version 2020.1)
Caution: ToolVersion.toString always renders the micro field,
    regardless whether ECU-TEST itself would omit it

<!--
Reference all issues related to this PR using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-->

<!--
Describe important changes proposed in this PR.
-->
