### PR TITLE
Remove deprecated configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 #!groovy
-buildPlugin(findbugs: [run: true, archive: true], checkstyle: [run: true, archive: true])
+buildPlugin()


### PR DESCRIPTION
Checkstyle and spotbugs are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, (assuming that checkstyle is bound to a phase in the build directly, the task is no longer directly invoked)