### PR TITLE
Hot fix for copying updated JACOB DLLs

### DIFF
--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/util/DllUtil.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/util/DllUtil.java
@@ -33,12 +33,12 @@ public final class DllUtil {
     /**
      * Defines the provided JACOB DLL for 32-bit systems.
      */
-    private static final String JACOB_DLL_X86 = "jacob-1.19-x86.dll";
+    private static final String JACOB_DLL_X86 = "jacob-1.20-x86.dll";
 
     /**
      * Defines the provided JACOB DLL for 64-bit systems.
      */
-    private static final String JACOB_DLL_X64 = "jacob-1.19-x64.dll";
+    private static final String JACOB_DLL_X64 = "jacob-1.20-x64.dll";
 
     /**
      * Instantiates a {@link DllUtil}.


### PR DESCRIPTION
<!--
Reference all issues related to this PR using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-->

<!--
Describe important changes proposed in this PR.
-->
With release 2.23.0 the COM API library JACOB was updated to 1.20 providing new DLL files. These libs will not be copied/updated properly on agents after a restart or deleting the lib folder in the agent home directory.
This may result in following exception: `[TT] ERROR: java.io.IOException: Could not copy JACOB library to Jenkins agent!`