### PR TITLE
Sensitive TEST-GUIDE settings are stored as secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ node('windows') {
     // TEST-GUIDE server instantiation using global variable ATX
     def atx = ATX.newServer atxName: 'TEST-GUIDE', toolName: 'ECU-TEST',
                             fullServerURL: 'http://localhost:8085', uploadToServer: false,
-                            authKey: 'xxx', projectId: '1'
+                            uploadAuthenticationKey: 'xxx', projectId: '1'
 
     // or getting existing instance from global configuration
     def atx = ATX.server('TEST-GUIDE')
@@ -617,17 +617,17 @@ unclassified:
           - atxTextSetting:
               group: CONNECTION
               name: "serverContextPath"
-          - atxTextSetting:
+          - atxSecretSetting:
               group: CONNECTION
               name: "httpProxy"
-          - atxTextSetting:
+          - atxSecretSetting:
               group: CONNECTION
               name: "httpsProxy"
           - atxTextSetting:
               group: CONNECTION
               name: "projectId"
               value: "1"
-          - atxTextSetting:
+          - atxSecretSetting:
               group: CONNECTION
               name: "uploadAuthenticationKey"
           - atxBooleanSetting:

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/AbstractATXReportHandler.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/AbstractATXReportHandler.java
@@ -11,6 +11,7 @@ import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXCustomB
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXCustomSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXCustomTextSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation;
+import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSecretSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting;
 import hudson.EnvVars;
@@ -89,8 +90,8 @@ public abstract class AbstractATXReportHandler {
         }
 
         /**
-         * Converts the ATX configuration to a map containing all setting names and their current value.
-         * Parameterized values are expanded by given environment variables.
+         * Converts the ATX configuration to a map containing all setting names and their current value. Parameterized
+         * values are expanded by given environment variables.
          *
          * @param uploadToServer  specifies whether ATX upload is enabled or not
          * @param injectBuildVars specifies whether to inject common build variables as ATX constants
@@ -106,6 +107,8 @@ public abstract class AbstractATXReportHandler {
                         configMap.put(setting.getName(),
                             ATXSetting.toString(((ATXBooleanSetting) setting).getValue()));
                     }
+                } else if (setting instanceof ATXSecretSetting) {
+                    configMap.put(setting.getName(), envVars.expand(((ATXSecretSetting) setting).getSecretValue()));
                 } else {
                     configMap.put(setting.getName(), envVars.expand(((ATXTextSetting) setting).getValue()));
                 }
@@ -120,10 +123,10 @@ public abstract class AbstractATXReportHandler {
             }
             if (injectBuildVars) {
                 final List<String> constants = Arrays.asList(
-                        configMap.get("setConstants"),
-                        formatConstant("BUILD_NUMBER"),
-                        formatConstant("BUILD_URL"),
-                        formatConstant("JOB_NAME"));
+                    configMap.get("setConstants"),
+                    formatConstant("BUILD_NUMBER"),
+                    formatConstant("BUILD_URL"),
+                    formatConstant("JOB_NAME"));
                 configMap.replace("setConstants", String.join(";", constants));
             }
             return configMap;

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXConfig.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXConfig.java
@@ -10,6 +10,7 @@ import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.util.Secret;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Document;
@@ -103,6 +104,11 @@ public class ATXConfig extends AbstractDescribableImpl<ATXConfig> implements Clo
                         final ATXBooleanSetting newSetting = new ATXBooleanSetting(settingName, settingsGroup,
                             descGerman, descEnglish, (Boolean) setting.getDefaultValue());
                         newSetting.setValue(((ATXBooleanSetting) setting).getValue());
+                        settings.add(newSetting);
+                    } else if (setting.isSecret()) {
+                        final ATXSecretSetting newSetting = new ATXSecretSetting(settingName, settingsGroup,
+                            descGerman, descEnglish, (Secret) setting.getDefaultValue());
+                        newSetting.setValue(((ATXSecretSetting) setting).getValue());
                         settings.add(newSetting);
                     } else {
                         final ATXTextSetting newSetting = new ATXTextSetting(settingName, settingsGroup,
@@ -208,12 +214,12 @@ public class ATXConfig extends AbstractDescribableImpl<ATXConfig> implements Clo
     /**
      * Gets the ATX setting value by given setting name from all ATX settings.
      *
-     * @param name     the setting name
+     * @param name the setting name
      * @return the setting value or {@code null} if not found
      */
     public Object getSettingValueByName(final String name) throws IllegalArgumentException {
         return getSettingByName(name).map(ATXSetting::getValue)
-                .orElseThrow(() -> new IllegalArgumentException("No setting found with name: " + name));
+            .orElseThrow(() -> new IllegalArgumentException("No setting found with name: " + name));
     }
 
     /**
@@ -254,8 +260,14 @@ public class ATXConfig extends AbstractDescribableImpl<ATXConfig> implements Clo
                 ((ATXTextSetting) setting).setValue((String) value);
             } else if (setting instanceof ATXBooleanSetting) {
                 ((ATXBooleanSetting) setting).setValue((Boolean) value);
+            } else if (setting instanceof ATXSecretSetting) {
+                if (value instanceof String) {
+                    ((ATXSecretSetting) setting).setValue(Secret.fromString((String) value));
+                } else {
+                    ((ATXSecretSetting) setting).setValue((Secret) value);
+                }
             } else {
-                throw new IllegalArgumentException("Only String and Boolean value types are supported!");
+                throw new IllegalArgumentException("Only String, Boolean and Secret value types are supported!");
             }
         });
     }

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallation.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallation.java
@@ -19,6 +19,7 @@ import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import hudson.tools.ToolInstallation;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import hudson.util.XStream2;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
@@ -328,7 +329,11 @@ public class ATXInstallation extends AbstractDescribableImpl<ATXInstallation> im
                 if (settingsGroup != null) {
                     final Object currentSetting = settingsGroup.opt(setting.getName());
                     if (currentSetting instanceof String) {
-                        ((ATXTextSetting) setting).setValue((String) currentSetting);
+                        if (setting.isSecret()) {
+                            ((ATXSecretSetting) setting).setValue(Secret.fromString((String) currentSetting));
+                        } else {
+                            ((ATXTextSetting) setting).setValue((String) currentSetting);
+                        }
                     } else if (currentSetting instanceof Boolean) {
                         ((ATXBooleanSetting) setting).setValue((Boolean) currentSetting);
                     }

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSecretSetting.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSecretSetting.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015-2020 TraceTronic GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package de.tracetronic.jenkins.plugins.ecutest.report.atx.installation;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Class holding the information of a secret-based ATX setting.
+ */
+public class ATXSecretSetting extends ATXSetting<Secret> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Instantiates a new {@link ATXSecretSetting}.
+     *
+     * @param name  the name
+     * @param group the settings group
+     * @param value the current value
+     */
+    @DataBoundConstructor
+    public ATXSecretSetting(final String name, final SettingsGroup group, final Secret value) {
+        super(name, group, value);
+    }
+
+    /**
+     * Instantiates a new {@link ATXSecretSetting} with default values.
+     *
+     * @param name         the name
+     * @param group        the settings group
+     * @param descGerman   the German description
+     * @param descEnglish  the English description
+     * @param defaultValue the default value
+     */
+    public ATXSecretSetting(final String name, final SettingsGroup group,
+                            final String descGerman, final String descEnglish,
+                            final Secret defaultValue) {
+        super(name, group, descGerman, descEnglish, defaultValue);
+    }
+
+    @Whitelisted
+    public String getSecretValue() {
+        return Secret.toString(value);
+    }
+
+    /**
+     * DescriptorImpl of {@link ATXSecretSetting}.
+     */
+    @Symbol("atxSecretSetting")
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ATXSetting<?>> {
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.ATXSecretSetting_DisplayName();
+        }
+    }
+}

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSetting.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSetting.java
@@ -171,12 +171,21 @@ public abstract class ATXSetting<T> extends AbstractDescribableImpl<ATXSetting<?
     }
 
     /**
-     * Gets the checkbox status from the current value.
+     * Determines whether this setting is checkbox type.
      *
-     * @return {@code true} if checkbox is checked, {@code false} otherwise
+     * @return {@code true} if setting is checkbox type, {@code false} otherwise
      */
     public boolean isCheckbox() {
         return this instanceof ATXBooleanSetting;
+    }
+
+    /**
+     * Determines whether this setting is secret type.
+     *
+     * @return {@code true} if setting is secret type, {@code false} otherwise
+     */
+    public boolean isSecret() {
+        return this instanceof ATXSecretSetting;
     }
 
     /**

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipeline.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipeline.java
@@ -7,6 +7,7 @@ package de.tracetronic.jenkins.plugins.ecutest.report.atx.pipeline;
 
 import com.google.common.collect.Maps;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXConfig;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 
@@ -128,7 +129,7 @@ public class ATXPipeline implements Serializable {
             throws MalformedURLException {
         final Map<String, Object> additionalSettings = Maps.newLinkedHashMap();
         additionalSettings.put("uploadToServer", uploadToServer);
-        additionalSettings.put("uploadAuthenticationKey", authKey);
+        additionalSettings.put("uploadAuthenticationKey", Secret.fromString(authKey));
         additionalSettings.put("projectId", projectId);
 
         return newServer(atxName, toolName, fullServerUrl, additionalSettings);

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXServer.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXServer.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 
@@ -133,6 +134,9 @@ public class ATXServer implements Serializable {
         if (setting.isPresent()) {
             if (settingValue instanceof String || settingValue instanceof Boolean) {
                 script.println(String.format("[TT] INFO: Overriding ATX setting %s=%s", settingName, settingValue));
+                installation.getConfig().setSettingValueByName(settingName, settingValue);
+            } else if (settingValue instanceof Secret) {
+                script.println(String.format("[TT] INFO: Overriding ATX secret setting %s", settingName));
                 installation.getConfig().setSettingValueByName(settingName, settingValue);
             } else {
                 script.println("[TT] WARN: Ignore overriding ATX setting due to invalid value!");

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallation/setting.jelly
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallation/setting.jelly
@@ -13,6 +13,9 @@
                     <f:checkbox name="${setting.getName()}" checked="${setting.getValue()}"
                                 default="${setting.getDefaultValue()}"/>
                 </j:when>
+                <j:when test="${setting.isSecret()}">
+                    <f:password name="${setting.getName()}" value="${setting.getValue()}"/>
+                </j:when>
                 <j:otherwise>
                     <f:textbox name="${setting.getName()}" value="${setting.getValue()}"
                                default="${setting.getDefaultValue()}"

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/Messages.properties
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/Messages.properties
@@ -23,4 +23,5 @@ ATXInstallation.NoValidatedConnection=Parameterized server settings cannot be ch
 ATXInstallation.NoValidatedValue=Value cannot be resolved at validation-time, be sure to allocate with a valid value.
 ATXInstallation.ServerNotReachable=Server at {0} could not be reached.\n{1}
 ATXInstallation.ValidConnection=Successfully connected to {0}
-ATXTextSetting.DisplayName=Text Parameter Setting
+ATXSecretSetting.DisplayName=Secret Setting
+ATXTextSetting.DisplayName=Text Setting

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/Messages_de.properties
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/Messages_de.properties
@@ -25,4 +25,5 @@ ATXInstallation.NoValidatedValue=Wert kann nicht direkt \u00FCberpr\u00FCft werd
     Variablenzuweisung muss g\u00FCltig sein.
 ATXInstallation.ServerNotReachable=Server unter {0} kann nicht erreicht werden.\n{1}
 ATXInstallation.ValidConnection=Verbindung zu {0} erfolgreich hergestellt.
-ATXTextSetting.DisplayName=Textparameter-Einstellung
+ATXSecretSetting.DisplayName=Passwort-Einstellung
+ATXTextSetting.DisplayName=Text-Einstellung

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGetServerStep/help.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGetServerStep/help.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2015-2019 TraceTronic GmbH
+  Copyright (c) 2015-2020 TraceTronic GmbH
 
   SPDX-License-Identifier: BSD-3-Clause
   -->
@@ -7,6 +7,9 @@
 <div>
     <p>Gets a TEST-GUIDE server instance by name which must be present in the TEST-GUIDE installations.
         Existing settings can be discovered and overridden afterwards.</p>
+    <p>For providing secrets like upload authentication key or proxy settings utilize
+        <a href="https://plugins.jenkins.io/credentials-binding/">credentials binding</a>
+        and pass as masked environment variables.</p>
     <dl>Signatures:
         <dd>
             <pre>

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGetServerStep/help_de.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGetServerStep/help_de.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2015-2019 TraceTronic GmbH
+  Copyright (c) 2015-2020 TraceTronic GmbH
 
   SPDX-License-Identifier: BSD-3-Clause
   -->
@@ -7,6 +7,9 @@
 <div>
     <p>Gibt eine TEST-GUIDE-Serverinstanz mit dem angegebenen Namen zurück, die in den TEST-GUIDE-Installationen
         vorhanden sein muss. Vorhandene Einstellungen können abgefragt und nachträglich überschrieben werden.</p>
+    <p>Vertrauliche Daten wie Upload-Authentifizierungsschlüssel oder Proxyeinstellungen sollten als maskierte
+        Umgebungsvariablen per <a href="https://plugins.jenkins.io/credentials-binding/">Credentials Binding</a>
+        übergeben werden.</p>
     <dl>Signatures:
         <dd>
             <pre>

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGlobalVariable/help.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXGlobalVariable/help.html
@@ -1,0 +1,15 @@
+<!--
+  Copyright (c) 2015-2020 TraceTronic GmbH
+
+  SPDX-License-Identifier: BSD-3-Clause
+  -->
+
+<div>
+    <p>
+        The <code>ATX</code> variable offers convenient access to dynamic TEST-GUIDE functions from a Pipeline script.
+    </p>
+    <p>
+        Refer to <a href="https://github.com/jenkinsci/ecutest-plugin#pipeline">README</a> or use the Pipeline Snippet
+        Generator for example usage.
+    </p>
+</div>

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXNewServerStep/help.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXNewServerStep/help.html
@@ -6,8 +6,11 @@
 
 <div>
     <p>Creates a new dynamic TEST-GUIDE server instance which is only accessible during pipeline execution.
-       TEST-GUIDE name (<i>atxName</i>) and used ECU-TEST installation (<i>toolName</i>) are required
-       whereas missing optional settings will be initialized to their default values.</p>
+        TEST-GUIDE name (<i>atxName</i>) and used ECU-TEST installation (<i>toolName</i>) are required
+        whereas missing optional settings will be initialized to their default values.</p>
+    <p>For providing secrets like upload authentication key or proxy settings utilize
+        <a href="https://plugins.jenkins.io/credentials-binding/">credentials binding</a>
+        and pass as masked environment variables.</p>
     <dl>Signatures:
         <dd>
             <pre>
@@ -62,10 +65,10 @@ ATX.newServer atxName: 'TEST-GUIDE', toolName: 'ECU-TEST',
             atxBooleanSetting(group: 'CONNECTION', name: 'ignoreSSL', value: false),
             atxTextSetting(group: 'CONNECTION', name: 'serverPort', value: '8085'),
             atxTextSetting(group: 'CONNECTION', name: 'serverContextPath', value: ''),
-            atxTextSetting(group: 'CONNECTION', name: 'httpProxy', value: ''),
-            atxTextSetting(group: 'CONNECTION', name: 'httpsProxy', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'httpProxy', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'httpsProxy', value: ''),
             atxTextSetting(group: 'CONNECTION', name: 'projectId', value: '1'),
-            atxTextSetting(group: 'CONNECTION', name: 'uploadAuthenticationKey', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'uploadAuthenticationKey', value: ''),
             atxBooleanSetting(group: 'CONNECTION', name: 'useSettingsFromServer', value: false),
             atxBooleanSetting(group: 'UPLOAD', name: 'uploadAsync', value: true),
             atxBooleanSetting(group: 'UPLOAD', name: 'uploadToServer', value: false),

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXNewServerStep/help_de.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXNewServerStep/help_de.html
@@ -6,8 +6,11 @@
 
 <div>
     <p>Erzeugt eine neue dynamische TEST-GUIDE-Serverinstanz, die nur während der Pipelineausführung verfügbar ist.
-       TEST-GUIDE-Name (<i>atxName</i>) und verwendete ECU-TEST-Installation (<i>toolName</i>) sind erforderlich
-       während fehlende optionale Einstellungen auf ihren Standardwert gesetzt werden.</p>
+        TEST-GUIDE-Name (<i>atxName</i>) und verwendete ECU-TEST-Installation (<i>toolName</i>) sind erforderlich
+        während fehlende optionale Einstellungen auf ihren Standardwert gesetzt werden.</p>
+    <p>Vertrauliche Daten wie Upload-Authentifizierungsschlüssel oder Proxyeinstellungen sollten als maskierte
+        Umgebungsvariablen per <a href="https://plugins.jenkins.io/credentials-binding/">Credentials Binding</a>
+        übergeben werden.</p>
     <dl>Signaturen:
         <dd>
             <pre>
@@ -62,10 +65,10 @@ ATX.newServer atxName: 'TEST-GUIDE', toolName: 'ECU-TEST',
             atxBooleanSetting(group: 'CONNECTION', name: 'ignoreSSL', value: false),
             atxTextSetting(group: 'CONNECTION', name: 'serverPort', value: '8085'),
             atxTextSetting(group: 'CONNECTION', name: 'serverContextPath', value: ''),
-            atxTextSetting(group: 'CONNECTION', name: 'httpProxy', value: ''),
-            atxTextSetting(group: 'CONNECTION', name: 'httpsProxy', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'httpProxy', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'httpsProxy', value: ''),
             atxTextSetting(group: 'CONNECTION', name: 'projectId', value: '1'),
-            atxTextSetting(group: 'CONNECTION', name: 'uploadAuthenticationKey', value: ''),
+            atxSecretSetting(group: 'CONNECTION', name: 'uploadAuthenticationKey', value: ''),
             atxBooleanSetting(group: 'CONNECTION', name: 'useSettingsFromServer', value: false),
             atxBooleanSetting(group: 'UPLOAD', name: 'uploadAsync', value: true),
             atxBooleanSetting(group: 'UPLOAD', name: 'uploadToServer', value: false),

--- a/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/tool/pipeline/ETGlobalVariable/help.html
+++ b/src/main/resources/de/tracetronic/jenkins/plugins/ecutest/tool/pipeline/ETGlobalVariable/help.html
@@ -1,0 +1,15 @@
+<!--
+  Copyright (c) 2015-2020 TraceTronic GmbH
+
+  SPDX-License-Identifier: BSD-3-Clause
+  -->
+
+<div>
+    <p>
+        The <code>ET</code> variable offers convenient access to dynamic ECU-TEST functions from a Pipeline script.
+    </p>
+    <p>
+        Refer to <a href="https://github.com/jenkinsci/ecutest-plugin#pipeline">README</a> or use the Pipeline Snippet
+        Generator for example usage.
+    </p>
+</div>

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2020 TraceTronic GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package de.tracetronic.jenkins.plugins.ecutest.report.atx.installation;
+
+import de.tracetronic.jenkins.plugins.ecutest.IntegrationTestBase;
+import de.tracetronic.jenkins.plugins.ecutest.report.atx.ATXPublisher;
+import org.junit.Test;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class ATXInstallationIT extends IntegrationTestBase {
+
+    @Test
+    @LocalData
+    public void testServerMigration() {
+        final ATXPublisher publisher = new ATXPublisher("TEST-GUIDE");
+        final ATXInstallation installation = publisher.getInstallation();
+        assertNotNull(installation);
+
+        assertMigratedSetting(installation, "httpProxy", "http://user:pass@10.10.10.2:8080");
+        assertMigratedSetting(installation, "httpsProxy", "http://user:pass@10.10.10.2:8080");
+        assertMigratedSetting(installation, "uploadAuthenticationKey", "API-TOKEN");
+    }
+
+    private void assertMigratedSetting(final ATXInstallation installation, final String settingName,
+                                       final String expectedValue) {
+        Optional<ATXSetting<?>> setting = installation.getConfig().getSettingByName(settingName);
+        assertThat(setting.isPresent(), is(true));
+        assertThat(setting.get(), instanceOf(ATXSecretSetting.class));
+        assertThat(((ATXSecretSetting) setting.get()).getSecretValue(), is(expectedValue));
+    }
+}

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSettingIT.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXSettingIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015-2020 TraceTronic GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package de.tracetronic.jenkins.plugins.ecutest.report.atx.installation;
+
+import de.tracetronic.jenkins.plugins.ecutest.IntegrationTestBase;
+import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting.SettingsGroup;
+import hudson.util.Secret;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for {@link ATXSetting}.
+ */
+public class ATXSettingIT extends IntegrationTestBase {
+
+    @Test
+    public void testSecretType() {
+        final ATXSecretSetting setting = new ATXSecretSetting("settingName", SettingsGroup.SPECIAL,
+            "descGerman", "descEnglish", Secret.fromString("defaultValue"));
+        assertTrue(setting.isSecret());
+    }
+
+    @Test
+    public void testCurrentValueForSecret() {
+        final ATXSecretSetting setting = new ATXSecretSetting("settingName", SettingsGroup.SPECIAL,
+            "descGerman", "descEnglish", Secret.fromString("defaultValue"));
+        setting.setValue(Secret.fromString("test"));
+        assertThat(setting.getSecretValue(), is("test"));
+    }
+
+    @Test
+    public void testDefaultValueForSecret() {
+        final ATXSecretSetting setting = new ATXSecretSetting("settingName", SettingsGroup.SPECIAL,
+            "descGerman", "descEnglish", Secret.fromString("defaultValue"));
+        assertThat(setting.getDefaultValue().getPlainText(), is("defaultValue"));
+    }
+}

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/test/TestFolderBuilderIT.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/test/TestFolderBuilderIT.java
@@ -109,7 +109,7 @@ public class TestFolderBuilderIT extends IntegrationTestBase {
         WebAssert.assertInputContainsValue(page, "_.timeout", "600");
         jenkins.assertXPath(page, "//input[@name='_.stopOnError' and @checked='true']");
         jenkins.assertXPath(page, "//input[@name='_.checkTestFile' and @checked='true']");
-        jenkins.assertXPath(page, "//input[@name='_.recordWarnings and @checked='false']");
+        jenkins.assertXPath(page, "//input[@name='_.recordWarnings' and @checked='false']");
     }
 
     @Test

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/util/ATXUtilTest.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/util/ATXUtilTest.java
@@ -7,10 +7,12 @@ package de.tracetronic.jenkins.plugins.ecutest.util;
 
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXConfig;
+import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSecretSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXSetting.SettingsGroup;
 import de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting;
 import hudson.EnvVars;
+import hudson.util.Secret;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -18,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
@@ -118,9 +119,9 @@ public class ATXUtilTest {
         final ATXTextSetting serverUrl = new ATXTextSetting("serverURL", SettingsGroup.CONNECTION, "", "", "localhost");
         final ATXTextSetting serverPort = new ATXTextSetting("serverPort", SettingsGroup.CONNECTION, "", "", "8086");
         final ATXTextSetting serverContextPath = new ATXTextSetting("serverContextPath", SettingsGroup.CONNECTION, "", "",
-                "context");
+            "context");
         final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", true);
+            "", true);
         uploadSettings.add(serverUrl);
         uploadSettings.add(serverPort);
         uploadSettings.add(serverContextPath);
@@ -136,10 +137,10 @@ public class ATXUtilTest {
         final List<ATXSetting<?>> uploadSettings = new ArrayList<>();
         final ATXTextSetting serverUrl = new ATXTextSetting("serverURL", SettingsGroup.CONNECTION, "", "", "${SERVER_URL}");
         final ATXTextSetting serverPort = new ATXTextSetting("serverPort", SettingsGroup.CONNECTION, "", "", "${SERVER_PORT}");
-        final ATXTextSetting serverContextPath = new ATXTextSetting("serverContextPath", SettingsGroup.CONNECTION, "", "", "$" +
-                "{SERVER_CONTEXT}");
+        final ATXTextSetting serverContextPath = new ATXTextSetting("serverContextPath", SettingsGroup.CONNECTION, "", "",
+            "${SERVER_CONTEXT}");
         final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", true);
+            "", true);
         uploadSettings.add(serverUrl);
         uploadSettings.add(serverPort);
         uploadSettings.add(serverContextPath);
@@ -170,18 +171,18 @@ public class ATXUtilTest {
     @Test
     public void testProxyUrlByDefaultConfig() {
         final ATXConfig atxConfig = new ATXConfig();
-        assertThat(ATXUtil.getProxyUrl(atxConfig, new EnvVars()), emptyString());
+        assertThat(ATXUtil.getProxyUrl(atxConfig, new EnvVars()), nullValue());
     }
 
     @Test
     public void testHttpProxyUrlBySpecificConfig() {
         final List<ATXSetting<?>> uploadSettings = new ArrayList<>();
-        final ATXTextSetting httpProxy = new ATXTextSetting("httpProxy", SettingsGroup.CONNECTION, "", "", "http://user:pass" +
-                "@127.0.0.1:8080");
-        final ATXTextSetting httpsProxy = new ATXTextSetting("httpsProxy", SettingsGroup.CONNECTION, "", "", "http://user:pass" +
-                "@127.0.0.1:8081");
-        final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", false);
+        final ATXSecretSetting httpProxy = new ATXSecretSetting("httpProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("http://user:pass@127.0.0.1:8080"));
+        final ATXSecretSetting httpsProxy = new ATXSecretSetting("httpsProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("http://user:pass@127.0.0.1:8081"));
+        final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection",
+            SettingsGroup.CONNECTION, "", "", false);
         uploadSettings.add(httpProxy);
         uploadSettings.add(httpsProxy);
         uploadSettings.add(useHttpsConnection);
@@ -194,12 +195,12 @@ public class ATXUtilTest {
     @Test
     public void testHttpsProxyUrlBySpecificConfig() {
         final List<ATXSetting<?>> uploadSettings = new ArrayList<>();
-        final ATXTextSetting httpProxy = new ATXTextSetting("httpProxy", SettingsGroup.CONNECTION, "", "", "http://user:pass" +
-                "@127.0.0.1:8080");
-        final ATXTextSetting httpsProxy = new ATXTextSetting("httpsProxy", SettingsGroup.CONNECTION, "", "", "http://user:pass" +
-                "@127.0.0.1:8081");
+        final ATXSecretSetting httpProxy = new ATXSecretSetting("httpProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("http://user:pass@127.0.0.1:8080"));
+        final ATXSecretSetting httpsProxy = new ATXSecretSetting("httpsProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("http://user:pass@127.0.0.1:8081"));
         final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", true);
+            "", true);
         uploadSettings.add(httpProxy);
         uploadSettings.add(httpsProxy);
         uploadSettings.add(useHttpsConnection);
@@ -212,9 +213,10 @@ public class ATXUtilTest {
     @Test
     public void testHttpProxyUrlByExpandedConfig() {
         final List<ATXSetting<?>> uploadSettings = new ArrayList<>();
-        final ATXTextSetting httpProxy = new ATXTextSetting("httpProxy", SettingsGroup.CONNECTION, "", "", "${PROXY_URL}");
+        final ATXSecretSetting httpProxy = new ATXSecretSetting("httpProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("${PROXY_URL}"));
         final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", false);
+            "", false);
         uploadSettings.add(httpProxy);
         uploadSettings.add(useHttpsConnection);
 
@@ -236,9 +238,10 @@ public class ATXUtilTest {
     @Test
     public void testHttpsProxyUrlByExpandedConfig() {
         final List<ATXSetting<?>> uploadSettings = new ArrayList<>();
-        final ATXTextSetting httpsProxy = new ATXTextSetting("httpsProxy", SettingsGroup.CONNECTION, "", "", "${PROXY_URL}");
+        final ATXSecretSetting httpsProxy = new ATXSecretSetting("httpsProxy", SettingsGroup.CONNECTION, "", "",
+            Secret.fromString("${PROXY_URL}"));
         final ATXBooleanSetting useHttpsConnection = new ATXBooleanSetting("useHttpsConnection", SettingsGroup.CONNECTION, "",
-                "", true);
+            "", true);
         uploadSettings.add(httpsProxy);
         uploadSettings.add(useHttpsConnection);
 

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT/testServerMigration/config.xml
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT/testServerMigration/config.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Copyright (c) 2015-2020 TraceTronic GmbH
+
+  SPDX-License-Identifier: BSD-3-Clause
+  -->
+<hudson>
+    <disabledAdministrativeMonitors/>
+    <version>2.60.3</version>
+    <numExecutors>2</numExecutors>
+    <mode>NORMAL</mode>
+    <useSecurity>true</useSecurity>
+    <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+    <securityRealm class="hudson.security.SecurityRealm$None"/>
+    <disableRememberMe>false</disableRememberMe>
+    <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+    <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+    <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+    <jdks/>
+    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+    <clouds/>
+    <slaves/>
+    <quietPeriod>5</quietPeriod>
+    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+    <views>
+        <hudson.model.AllView>
+            <owner class="hudson" reference="../../.."/>
+            <name>All</name>
+            <filterExecutors>false</filterExecutors>
+            <filterQueue>false</filterQueue>
+            <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+    </views>
+    <primaryView>All</primaryView>
+    <slaveAgentPort>0</slaveAgentPort>
+    <label></label>
+    <nodeProperties/>
+    <globalNodeProperties/>
+</hudson>

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT/testServerMigration/de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation.xml
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/ATXInstallationIT/testServerMigration/de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation.xml
@@ -1,0 +1,329 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Copyright (c) 2015-2020 TraceTronic GmbH
+
+  SPDX-License-Identifier: BSD-3-Clause
+  -->
+<de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation_-DescriptorImpl plugin="ecutest@2.22">
+    <installations>
+        <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation>
+            <name>TEST-GUIDE</name>
+            <toolName>${ECUTEST}</toolName>
+            <config>
+                <settings>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">127.0.0.1</value>
+                        <name>serverURL</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>serverLabel</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>useHttpsConnection</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>ignoreSSL</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">8085</value>
+                        <name>serverPort</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>serverContextPath</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">http://user:pass@10.10.10.2:8080</value>
+                        <name>httpProxy</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">http://user:pass@10.10.10.2:8080</value>
+                        <name>httpsProxy</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">1</value>
+                        <name>projectId</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">API-TOKEN</value>
+                        <name>uploadAuthenticationKey</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>useSettingsFromServer</name>
+                        <group>CONNECTION</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>uploadToServer</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">0</value>
+                        <name>uploadThroughResourceAdapter</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>uploadAsync</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">42</value>
+                        <name>maxUploadTries</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>compressUpload</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>cleanAfterSuccessUpload</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>uploadOnlyProjectReport</name>
+                        <group>UPLOAD</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>enableArchive</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archiveTrf</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>archivePkg</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>archiveTcf</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>archiveTbc</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>archiveMapping</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>archiveRecordings</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archiveRecordingMetadata</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archivePlots</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archiveImages</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>archiveMiscFiles</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>archiveMiscFilePrefix</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archiveMiscFilesOnlyInTestReportDir</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>archiveFilesPerPackage</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">NONE;SUCCESS;INCONCLUSIVE;FAILED;ERROR</value>
+                        <name>archiveBy</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>archiveDescriptionImages</name>
+                        <group>ARCHIVE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">Testlevel;Designer;Execution Priority;Estimated Duration [min];</value>
+                        <name>coveredAttributes</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>attributeDelimiter</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapIsTestCaseAsAttribute</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapTestCaseVersionAsAttribute</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapRootPrjAttrToPkgAttr</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>excludePrjAttrPrefixFor</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>includePkgSVNRevision</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapSwkIdsAsAttribute</name>
+                        <group>ATTRIBUTE</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapTbcToolAsConstant</name>
+                        <group>TBC_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>mapTcfTesterAsConstant</name>
+                        <group>TCF_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapTCFPropertyAsConstant</name>
+                        <group>TCF_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>mapUserDefinedReportDataAsConstant</name>
+                        <group>TCF_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>setConstants</name>
+                        <group>TCF_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>setAttributes</name>
+                        <group>TCF_CONSTANTS</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>setReviewTags</name>
+                        <group>REVIEW</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>reviewUseAbortCodeAsCustomEvaluation</name>
+                        <group>REVIEW</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>autoATXGeneratorUpdate</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>includeToolIdentifier</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>includePkgTestSteps</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>onlyIncludePkgTestCases</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>overrideParamSetNameMapping</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>mapProjectElementNameAsTestCaseName</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string">0</value>
+                        <name>mapSubPackageAsTestCaseLevel</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>captureSubPackageOnVerdict</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>mapSeparateProjectExecutionAsSingleTestplan</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                        <value class="string"></value>
+                        <name>mapAttributeAsConstant</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXTextSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">false</value>
+                        <name>mapTestReportPathAsConstant</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                    <de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                        <value class="boolean">true</value>
+                        <name>includeResourceAdapterInfo</name>
+                        <group>SPECIAL</group>
+                    </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXBooleanSetting>
+                </settings>
+                <customSettings/>
+            </config>
+        </de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation>
+    </installations>
+</de.tracetronic.jenkins.plugins.ecutest.report.atx.installation.ATXInstallation_-DescriptorImpl>

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/casc-export.yml
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/casc-export.yml
@@ -30,17 +30,17 @@ installations:
     - atxTextSetting:
         group: CONNECTION
         name: "serverContextPath"
-    - atxTextSetting:
+    - atxSecretSetting:
         group: CONNECTION
         name: "httpProxy"
-    - atxTextSetting:
+    - atxSecretSetting:
         group: CONNECTION
         name: "httpsProxy"
     - atxTextSetting:
         group: CONNECTION
         name: "projectId"
         value: "1"
-    - atxTextSetting:
+    - atxSecretSetting:
         group: CONNECTION
         name: "uploadAuthenticationKey"
     - atxBooleanSetting:

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/casc.yml
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/installation/casc.yml
@@ -26,17 +26,17 @@ unclassified:
             - atxTextSetting:
                 group: CONNECTION
                 name: "serverContextPath"
-            - atxTextSetting:
+            - atxSecretSetting:
                 group: CONNECTION
                 name: "httpProxy"
-            - atxTextSetting:
+            - atxSecretSetting:
                 group: CONNECTION
                 name: "httpsProxy"
             - atxTextSetting:
                 group: CONNECTION
                 name: "projectId"
                 value: "1"
-            - atxTextSetting:
+            - atxSecretSetting:
                 group: CONNECTION
                 name: "uploadAuthenticationKey"
             - atxBooleanSetting:

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipelineIT/atxNewServer.groovy
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipelineIT/atxNewServer.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2015-2020 TraceTronic GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 def server = ATX.newServer('TEST-GUIDE', 'ECU-TEST')
 assertDefaultSettings(server)
 
@@ -18,7 +23,7 @@ def assertDefaultSettings(server) {
     assert server.getSetting('serverPort').value == '8085'
     assert server.getSetting('useHttpsConnection').value == false
     assert server.getSetting('serverContextPath').value == ''
-    assert server.getSetting('uploadAuthenticationKey').value == ''
+    assert server.getSetting('uploadAuthenticationKey').secretValue == ''
     assert server.getSetting('projectId').value == '1'
 }
 
@@ -31,6 +36,6 @@ def assertCustomSettings(server) {
     assert server.getSetting('serverPort').value == '443'
     assert server.getSetting('useHttpsConnection').value == true
     assert server.getSetting('serverContextPath').value == 'test'
-    assert server.getSetting('uploadAuthenticationKey').value == 'auth-123'
+    assert server.getSetting('uploadAuthenticationKey').secretValue == 'auth-123'
     assert server.getSetting('projectId').value == '42'
 }

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipelineIT/atxOverrideSetting.groovy
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/report/atx/pipeline/ATXPipelineIT/atxOverrideSetting.groovy
@@ -1,8 +1,16 @@
+/*
+ * Copyright (c) 2015-2020 TraceTronic GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 def server = ATX.server('TEST-GUIDE')
 assert server.getSetting('uploadToServer').value == false
 
 server.overrideSetting('uploadToServer', true)
 assert server.getSetting('uploadToServer').value == true
+
+server.overrideSetting('uploadAuthenticationKey', 'auth-123')
+assert server.getSetting('uploadAuthenticationKey').secretValue == 'auth-123'
 
 def settings = [serverURL: 'test.abc', useHttpsConnection: true]
 server.overrideSettings(settings)


### PR DESCRIPTION
<!--
Reference all issues related to this PR using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-->

<!--
Describe important changes proposed in this PR.
-->
The following TEST-GUIDE settings are now stored as secrets: `httpProxy`, `httpsProxy` and `uploadAuthenticationKey`

For providing secrets utilize [credentials binding](https://plugins.jenkins.io/credentials-binding) and pass as masked environment variables in dynamic pipelines.
According configuration-as-code settings changed from `atxTextSetting` to `atxSecretSetting` and should be adapted.
See example usage in [README](https://github.com/jenkinsci/ecutest-plugin#configuration-as-code).

Existing TEST-GUIDE configurations will be migrated automatically on Jenkins restart.