### PR TITLE
Hot fix for searching the ECU-TEST executable

### DIFF
--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/tool/client/AbstractToolClient.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/tool/client/AbstractToolClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 TraceTronic GmbH
+ * Copyright (c) 2015-2021 TraceTronic GmbH
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -102,6 +102,8 @@ public abstract class AbstractToolClient implements ToolClient {
                 logger.logError(String.format("-> Timeout of %d seconds reached! This can also be caused by an "
                     + "invalid  license.", getTimeout()));
             }
+            // Wait a moment before polling COM server
+            Thread.sleep(3000L);
         } catch (final IOException e) {
             logger.logError("-> Command line execution failed: " + e.getMessage());
         }

--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/tool/installation/AbstractToolInstallation.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/tool/installation/AbstractToolInstallation.java
@@ -5,8 +5,6 @@
  */
 package de.tracetronic.jenkins.plugins.ecutest.tool.installation;
 
-import hudson.EnvVars;
-import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.EnvironmentSpecific;
@@ -14,8 +12,6 @@ import hudson.slaves.NodeSpecific;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolProperty;
 
-import javax.annotation.CheckForNull;
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
@@ -59,35 +55,5 @@ public abstract class AbstractToolInstallation extends ToolInstallation implemen
      * @throws IOException          signals that an I/O exception has occurred
      * @throws InterruptedException if the current thread is interrupted while waiting for the completion
      */
-    public String getExecutable(final Launcher launcher) throws IOException, InterruptedException {
-        if (getExeFile() != null) {
-            final FilePath exeFilePath = new FilePath(launcher.getChannel(), getExeFile().getAbsolutePath());
-            return exeFilePath.exists() ? exeFilePath.getRemote() : null;
-        }
-        return null;
-    }
-
-    /**
-     * Gets the expanded executable file path.
-     *
-     * @return the executable file path or {@code null} if home directory is not set
-     */
-    @CheckForNull
-    private File getExeFile() {
-        if (getHome() != null) {
-            final String home = Util.replaceMacro(getHome(), EnvVars.masterEnvVars);
-            if (home != null) {
-                return getExeFile(new File(home));
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Gets the executable file relative to given home directory.
-     *
-     * @param home the home directory of the tool
-     * @return the executable file
-     */
-    protected abstract File getExeFile(File home);
+    public abstract String getExecutable(Launcher launcher) throws IOException, InterruptedException;
 }

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/tool/installation/ETInstallationIT.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/tool/installation/ETInstallationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 TraceTronic GmbH
+ * Copyright (c) 2015-2021 TraceTronic GmbH
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,12 +9,15 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import de.tracetronic.jenkins.plugins.ecutest.IntegrationTestBase;
 import hudson.EnvVars;
+import hudson.Launcher;
 import hudson.slaves.DumbSlave;
 import hudson.tools.ToolLocationNodeProperty;
 import org.junit.Test;
 import org.jvnet.hudson.test.recipes.LocalData;
 
+import java.io.File;
 import java.util.Collections;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -105,5 +108,62 @@ public class ETInstallationIT extends IntegrationTestBase {
         assertEquals(etDescriptor, location.getType());
         assertEquals("ECU-TEST", location.getName());
         assertEquals("C:\\ECU-TEST", location.getHome());
+    }
+
+    @Test
+    public void testExecutable() throws Exception {
+        DumbSlave agent = assumeWindowsSlave();
+        String exeFilePath = new File("C:\\ECU-TEST", "ECU-TEST.exe").getAbsolutePath();
+        Objects.requireNonNull(agent.createPath(exeFilePath)).write();
+
+        final ETInstallation.DescriptorImpl etDescriptor = jenkins.jenkins
+            .getDescriptorByType(ETInstallation.DescriptorImpl.class);
+        etDescriptor.setInstallations(new ETInstallation("ECU-TEST", "C:\\ECU-TEST", null));
+        final ETInstallation[] installations = etDescriptor.getInstallations();
+        assertEquals(1, installations.length);
+
+        final ETInstallation inst = installations[0];
+        final Launcher launcher = agent.createLauncher(jenkins.createTaskListener());
+
+        String executable = inst.getExecutable(launcher);
+        assertEquals(exeFilePath, executable);
+    }
+
+    @Test
+    public void testComExecutable() throws Exception {
+        DumbSlave agent = assumeWindowsSlave();
+        String exeFilePath = new File("C:\\ECU-TEST", "ECU-TEST_COM.exe").getAbsolutePath();
+        Objects.requireNonNull(agent.createPath(exeFilePath)).write();
+
+        final ETInstallation.DescriptorImpl etDescriptor = jenkins.jenkins
+            .getDescriptorByType(ETInstallation.DescriptorImpl.class);
+        etDescriptor.setInstallations(new ETInstallation("ECU-TEST", "C:\\ECU-TEST", null));
+        final ETInstallation[] installations = etDescriptor.getInstallations();
+        assertEquals(1, installations.length);
+
+        final ETInstallation inst = installations[0];
+        final Launcher launcher = agent.createLauncher(jenkins.createTaskListener());
+
+        String executable = inst.getComExecutable(launcher);
+        assertEquals(exeFilePath, executable);
+    }
+
+    @Test
+    public void testTSExecutable() throws Exception {
+        DumbSlave agent = assumeWindowsSlave();
+        String exeFilePath = new File("C:\\ECU-TEST", "Tool-Server.exe").getAbsolutePath();
+        Objects.requireNonNull(agent.createPath(exeFilePath)).write();
+
+        final ETInstallation.DescriptorImpl etDescriptor = jenkins.jenkins
+            .getDescriptorByType(ETInstallation.DescriptorImpl.class);
+        etDescriptor.setInstallations(new ETInstallation("ECU-TEST", "C:\\ECU-TEST", null));
+        final ETInstallation[] installations = etDescriptor.getInstallations();
+        assertEquals(1, installations.length);
+
+        final ETInstallation inst = installations[0];
+        final Launcher launcher = agent.createLauncher(jenkins.createTaskListener());
+
+        String executable = inst.getTSExecutable(launcher);
+        assertEquals(exeFilePath, executable);
     }
 }


### PR DESCRIPTION
<!--
Reference all issues related to this PR using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-->

<!--
Describe important changes proposed in this PR.
-->
With release 2.25.0 the XStream compatibility was fixed (#267) introducing a regression on a Linux master setup which fails in searching for the ECU-TEST executable on Windows agents.
This results in following exception: `[TT] ERROR: ECU-TEST executable could not be found!`.

Furthermore, a COM connection might fail after starting the ECU-TEST process on very fast machines which is now fixed by waiting a short moment before polling the COM server.