### PR TITLE
Hide package checks without warnings

### DIFF
--- a/src/main/java/de/tracetronic/jenkins/plugins/ecutest/test/client/AbstractTestClient.java
+++ b/src/main/java/de/tracetronic/jenkins/plugins/ecutest/test/client/AbstractTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 TraceTronic GmbH
+ * Copyright (c) 2015-2021 TraceTronic GmbH
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -135,7 +135,7 @@ public abstract class AbstractTestClient implements TestClient {
      * @param workspace the workspace
      * @param launcher  the launcher
      * @param listener  the listener
-     * @return {@code true} if recording detects any issues with error severity, {@code false} otherwise
+     * @return {@code true} if recording detects any issues with ERROR severity, {@code false} otherwise
      */
     protected boolean recordWarnings(final TestInfoHolder testInfo, final Run<?, ?> run, final FilePath workspace,
                                      final Launcher launcher, final TaskListener listener)
@@ -147,7 +147,7 @@ public abstract class AbstractTestClient implements TestClient {
             return true;
         }
 
-        boolean hasIssues = false;
+        boolean hasErrors = false;
         if (StringUtils.isNotBlank(testInfo.warningsIssues)) {
             final String issueFileName = "issues.json";
             final FilePath issuesFile = workspace.child(issueFileName);
@@ -156,12 +156,12 @@ public abstract class AbstractTestClient implements TestClient {
 
                 final WarningsRecorder recorder = new WarningsRecorder(
                     "Package Check", testInfo.getTestName(), issueFileName);
-                hasIssues = recorder.record(run, workspace, launcher, listener);
+                hasErrors = recorder.record(run, workspace, launcher, listener);
             } finally {
                 issuesFile.delete();
             }
         }
-        return hasIssues;
+        return hasErrors;
     }
 
     /**

--- a/src/test/java/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT.java
+++ b/src/test/java/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT.java
@@ -12,11 +12,16 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import io.jenkins.plugins.analysis.core.model.ResultAction;
 import org.junit.Test;
 import org.jvnet.hudson.test.TestBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Integration tests for {@link WarningsRecorder}.
@@ -24,10 +29,46 @@ import java.util.Objects;
 public class WarningsRecorderIT extends IntegrationTestBase {
 
     @Test
-    public void recordWarnings() throws Exception {
+    public void recordIssues() throws Exception {
         final String issueFileName = "issues.json";
         final String issues = loadTestResource(issueFileName);
 
+        final FreeStyleProject project = createProject(issueFileName, issues);
+        final FreeStyleBuild build = jenkins.buildAndAssertStatus(Result.SUCCESS, project);
+        jenkins.assertLogContains("found 1 file", build);
+        jenkins.assertLogContains("found 3 issues", build);
+
+        assertThat(build.getAction(ResultAction.class).getResult().getIssues().size(), is(3));
+    }
+
+    @Test
+    public void recordNoIssues() throws Exception {
+        final String issueFileName = "no-issues.json";
+        final String issues = loadTestResource(issueFileName);
+
+        final FreeStyleProject project = createProject(issueFileName, issues);
+        final FreeStyleBuild build = jenkins.buildAndAssertStatus(Result.SUCCESS, project);
+        jenkins.assertLogContains("found 1 file", build);
+        jenkins.assertLogContains("found 0 issues", build);
+        jenkins.assertLogContains("No issues found, empty result will be removed from build!", build);
+
+        assertThat(build.getAction(ResultAction.class), is(nullValue()));
+    }
+
+    @Test
+    public void recordError() throws Exception {
+        final String issueFileName = "error.json";
+        final String issues = loadTestResource(issueFileName);
+
+        final FreeStyleProject project = createProject(issueFileName, issues);
+        final FreeStyleBuild build = jenkins.buildAndAssertStatus(Result.FAILURE, project);
+        jenkins.assertLogContains("found 1 file", build);
+        jenkins.assertLogContains("found 1 issue", build);
+
+        assertThat(build.getAction(ResultAction.class).getResult().getTotalErrorsSize(), is(1));
+    }
+
+    private FreeStyleProject createProject(final String issueFileName, final String issues) throws IOException {
         final FreeStyleProject project = jenkins.createFreeStyleProject();
         project.getBuildersList().add(new TestBuilder() {
 
@@ -40,9 +81,6 @@ public class WarningsRecorderIT extends IntegrationTestBase {
                 return !recorder.record(build, build.getWorkspace(), launcher, listener);
             }
         });
-
-        final FreeStyleBuild build = jenkins.buildAndAssertStatus(Result.SUCCESS, project);
-        jenkins.assertLogContains("found 1 file", build);
-        jenkins.assertLogContains("found 3 issues", build);
+        return project;
     }
 }

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT/error.json
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT/error.json
@@ -1,0 +1,12 @@
+{
+  "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+  "issues": [
+    {
+      "description": "#1 Issue",
+      "fileName": "test.pkg",
+      "lineStart": 1,
+      "severity": "ERROR"
+    }
+  ],
+  "size": 1
+}

--- a/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT/no-issues.json
+++ b/src/test/resources/de/tracetronic/jenkins/plugins/ecutest/extension/warnings/WarningsRecorderIT/no-issues.json
@@ -1,0 +1,5 @@
+{
+  "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+  "issues": [],
+  "size": 0
+}


### PR DESCRIPTION
<!--
Reference all issues related to this PR using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-->

<!--
Describe important changes proposed in this PR.
-->
Resolves #227

Empty package check results without issues will be removed from build and are no longer linked on build summary page.
